### PR TITLE
Remove app name from titlebar

### DIFF
--- a/Indirect/MainPage.xaml
+++ b/Indirect/MainPage.xaml
@@ -76,12 +76,7 @@
                 <Button x:Name="BackButtonPlaceholder" Style="{StaticResource NavigationBackButtonNormalStyle}"
                         Height="32" Width="40" Opacity="0"
                         Visibility="Collapsed">
-                </Button>
-                <TextBlock x:Name="AppTitleTextBlock"
-                           Text="Indirect" 
-                           VerticalAlignment="Center"
-                           Style="{ThemeResource FluentCaptionTextStyle}" 
-                           Margin="13,0,0,0"/>
+                </Button>                
             </StackPanel>
         </Grid>
 

--- a/Indirect/MainPage.xaml.cs
+++ b/Indirect/MainPage.xaml.cs
@@ -87,14 +87,12 @@ namespace Indirect
         {
             if (e.WindowActivationState == CoreWindowActivationState.Deactivated)
             {
-                BackButton.IsEnabled = false;
-                AppTitleTextBlock.Opacity = 0.5;
+                BackButton.IsEnabled = false;                
             }
             else
             {
 
-                BackButton.IsEnabled = true;
-                AppTitleTextBlock.Opacity = 1;
+                BackButton.IsEnabled = true;                
             }
         }
 


### PR DESCRIPTION
Currently I find too much reduntant the presence of the textbox "Directs" along with the app name in the titlebar, so I think it should be removed